### PR TITLE
Fixed msg template (wrong class) and updated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Live demo](http://ws42.pogoapp.com/)
+[Live demo](http://ws42-demo.pogoapp.com/)
 
 Just a little example chat app using Rails 4, Ruby 2, and WebSockets.
 

--- a/app/assets/javascripts/chat.js.coffee
+++ b/app/assets/javascripts/chat.js.coffee
@@ -11,7 +11,7 @@ class Chat.Controller
   template: (message) ->
     html =
       """
-      <div class="message" >
+      <div class="messages" >
         <label class="label label-info">
           [#{message.received}] #{message.user_name}
         </label>&nbsp;


### PR DESCRIPTION
The link of the live demo is currently broken. I updated it. Also, the
chat wasn’t scrolling down on its own upon receiving new messages and
it also wasn’t deleting messages past the 15 message limit. This is
only because the message template was not named correctly.
